### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,5 +1,8 @@
 name: Test deployment
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/sebdanielsson/gik2f8-h21sebda-lab1/security/code-scanning/1](https://github.com/sebdanielsson/gik2f8-h21sebda-lab1/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily performs read-only operations and does not push changes to the repository or interact with pull requests, the minimal required permissions are `contents: read`. The `permissions` block can be added at the workflow level (applies to all jobs) or specifically to the `test-build` job. In this case, it is appropriate to add it to the workflow level to cover all current and potential future jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
